### PR TITLE
[WIP] Include screenshots

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ gem 'headless', "~> 1.0.2"
 gem 'watir-webdriver', git: 'https://github.com/watir/watir-webdriver.git'
 gem 'watir-webdriver-performance', "~> 0.2.4"
 gem 'activesupport'
+gem 'carrierwave', "0.4.10"
+gem 'aws'
+gem "aws-s3"
+
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,9 +14,18 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
-    addressable (2.3.5)
+    addressable (2.3.8)
     atomic (1.1.14)
+    aws (2.10.2)
+      http_connection
+      uuidtools
+      xml-simple
+    aws-s3 (0.6.3)
+      builder
+      mime-types
+      xml-simple
     builder (3.2.2)
+    carrierwave (0.4.10)
     childprocess (0.5.5)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.0)
@@ -24,7 +33,7 @@ GEM
     faraday (0.8.8)
       multipart-post (~> 1.2.0)
     ffi (1.9.6)
-    git (1.2.6)
+    git (1.2.9.1)
     github_api (0.10.1)
       addressable
       faraday (~> 0.8.1)
@@ -32,10 +41,10 @@ GEM
       multi_json (~> 1.4)
       nokogiri (~> 1.5.2)
       oauth2
-    hashie (2.0.5)
+    hashie (3.4.1)
     headless (1.0.2)
-    highline (1.6.20)
-    httpauth (0.2.0)
+    highline (1.7.1)
+    http_connection (1.4.4)
     i18n (0.6.9)
     jeweler (1.8.8)
       builder
@@ -47,27 +56,26 @@ GEM
       rake
       rdoc
     json (1.8.1)
-    jwt (0.1.8)
-      multi_json (>= 1.5)
+    jwt (1.4.1)
     method_source (0.8.2)
+    mime-types (2.4.3)
     minitest (4.7.5)
     multi_json (1.8.2)
     multi_xml (0.5.5)
     multipart-post (1.2.0)
     nokogiri (1.5.10)
-    oauth2 (0.9.2)
-      faraday (~> 0.8)
-      httpauth (~> 0.2)
-      jwt (~> 0.1.4)
-      multi_json (~> 1.0)
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (~> 1.2)
     pry (0.9.12.4)
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
-    rack (1.5.2)
-    rake (10.1.0)
+    rack (1.6.0)
+    rake (10.4.2)
     rdoc (3.12.2)
       json (~> 1.4)
     rspec (2.14.1)
@@ -88,17 +96,22 @@ GEM
     thread_safe (0.1.3)
       atomic
     tzinfo (0.3.38)
+    uuidtools (2.1.5)
     watir-webdriver-performance (0.2.4)
       watir-webdriver
       watir-webdriver
     websocket (1.2.1)
+    xml-simple (1.1.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activesupport
+  aws
+  aws-s3
   bundler (~> 1.0)
+  carrierwave (= 0.4.10)
   headless (~> 1.0.2)
   jeweler (~> 1.8.7)
   pry

--- a/lib/uptime_monitor.rb
+++ b/lib/uptime_monitor.rb
@@ -12,11 +12,22 @@ def require_all(path)
   end
 end
 
-CarrierWave.configure do |config|
-  config.s3_access_key_id =  ENV['AWS_ACCESS_KEY_ID']
-  config.s3_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
-  config.s3_bucket = ENV['RAGIOS_HERCULES_S3_DIR']
+def setup_screenshot_dir
+  FileUtils.mkdir_p RAGIOS_HERCULES_SCREENSHOT_DIR
+  FileUtils.rm_rf(Dir.glob("#{RAGIOS_HERCULES_SCREENSHOT_DIR}/*"))
 end
 
-CarrierWave.clean_cached_files!
+RAGIOS_HERCULES_SCREENSHOT_DIR = "#{Dir.pwd}/screenshots/tmp"
+RAGIOS_HERCULES_ENABLE_SCREENSHOTS = ENV['RAGIOS_HERCULES_ENABLE_SCREENSHOTS'] == 'true' ? true : false
+
+if RAGIOS_HERCULES_ENABLE_SCREENSHOTS
+  setup_screenshot_dir
+  CarrierWave.configure do |config|
+    config.s3_access_key_id =  ENV['AWS_ACCESS_KEY_ID']
+    config.s3_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
+    config.s3_bucket = ENV['RAGIOS_HERCULES_S3_DIR']
+  end
+  CarrierWave.clean_cached_files! 
+end
+
 require_all '/uptime_monitor'

--- a/lib/uptime_monitor.rb
+++ b/lib/uptime_monitor.rb
@@ -17,4 +17,6 @@ CarrierWave.configure do |config|
   config.s3_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
   config.s3_bucket = ENV['RAGIOS_HERCULES_S3_DIR']
 end
+
+CarrierWave.clean_cached_files!
 require_all '/uptime_monitor'

--- a/lib/uptime_monitor.rb
+++ b/lib/uptime_monitor.rb
@@ -3,6 +3,8 @@ require 'watir-webdriver'
 require 'watir-webdriver-performance'
 require 'ostruct'
 require 'active_support'
+require 'carrierwave'
+require 'aws'
 
 def require_all(path)
   Dir.glob(File.dirname(__FILE__) + path + '/*.rb') do |file|
@@ -10,4 +12,9 @@ def require_all(path)
   end
 end
 
+CarrierWave.configure do |config|
+  config.s3_access_key_id =  ENV['AWS_ACCESS_KEY_ID']
+  config.s3_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
+  config.s3_bucket = ENV['RAGIOS_HERCULES_S3_DIR']
+end
 require_all '/uptime_monitor'

--- a/lib/uptime_monitor/browser.rb
+++ b/lib/uptime_monitor/browser.rb
@@ -113,7 +113,7 @@ module Hercules
         filename = "screenshot#{Time.now.to_i}.png"
         @browser.screenshot.save(filename)
         file = File.open(filename)
-        uploader = Hercules::ScreenShotUploader.new
+        uploader = Hercules::UptimeMonitor::ScreenShotUploader.new
         uploader.store!(file)
         uploader.url
       end

--- a/lib/uptime_monitor/browser.rb
+++ b/lib/uptime_monitor/browser.rb
@@ -110,7 +110,12 @@ module Hercules
         false
       end
       def capture_screenshot
-       @browser.screenshot.save "screenshot.png"
+        filename = "screenshot#{Time.now.to_i}.png"
+        @browser.screenshot.save(filename)
+        file = File.open(filename)
+        uploader = Hercules::ScreenShotUploader.new
+        uploader.store!(file)
+        uploader.url
       end
     private
       def goto(url, browser_name)

--- a/lib/uptime_monitor/browser.rb
+++ b/lib/uptime_monitor/browser.rb
@@ -109,6 +109,9 @@ module Hercules
       rescue Watir::Wait::TimeoutError
         false
       end
+      def capture_screenshot
+       @browser.screenshot.save "screenshot.png"
+      end
     private
       def goto(url, browser_name)
         client = Selenium::WebDriver::Remote::Http::Default.new

--- a/lib/uptime_monitor/browser.rb
+++ b/lib/uptime_monitor/browser.rb
@@ -110,7 +110,7 @@ module Hercules
         false
       end
       def capture_screenshot
-        filename = "screenshot#{Time.now.to_i}.png"
+        filename = "#{RAGIOS_HERCULES_SCREENSHOT_DIR}/screenshot#{Time.now.to_i}.png"
         @browser.screenshot.save(filename)
         file = File.open(filename)
         uploader = Hercules::UptimeMonitor::ScreenShotUploader.new

--- a/lib/uptime_monitor/screen_shot_config.rb
+++ b/lib/uptime_monitor/screen_shot_config.rb
@@ -1,0 +1,6 @@
+module Hercules
+  module UptimeMonitor
+    class ScreenShotConfig
+    end
+  end
+end

--- a/lib/uptime_monitor/screen_shot_config.rb
+++ b/lib/uptime_monitor/screen_shot_config.rb
@@ -1,6 +1,0 @@
-module Hercules
-  module UptimeMonitor
-    class ScreenShotConfig
-    end
-  end
-end

--- a/lib/uptime_monitor/screen_shot_uploader.rb
+++ b/lib/uptime_monitor/screen_shot_uploader.rb
@@ -1,5 +1,7 @@
 module Hercules
-  class ScreenShotUploader < CarrierWave::Uploader::Base
-    storage :s3
+  module UptimeMonitor
+    class ScreenShotUploader < CarrierWave::Uploader::Base
+      storage :s3
+    end
   end
 end

--- a/lib/uptime_monitor/screen_shot_uploader.rb
+++ b/lib/uptime_monitor/screen_shot_uploader.rb
@@ -1,0 +1,5 @@
+module Hercules
+  class ScreenShotUploader < CarrierWave::Uploader::Base
+    storage :s3
+  end
+end

--- a/lib/uptime_monitor/uptime_monitor.rb
+++ b/lib/uptime_monitor/uptime_monitor.rb
@@ -4,6 +4,8 @@ module Ragios
       attr_reader :monitor
       attr_reader :test_result
       attr_reader :success
+      attr_reader :screenshot_url
+      attr_reader :has_screenshot
 
       def initialize
         @test_result = ActiveSupport::OrderedHash.new

--- a/lib/uptime_monitor/uptime_monitor.rb
+++ b/lib/uptime_monitor/uptime_monitor.rb
@@ -8,7 +8,7 @@ module Ragios
       def initialize
         @test_result = ActiveSupport::OrderedHash.new
         @result_set = []
-        @test_result = {results: @result_set }
+        @test_result = {results: @result_set}
       end
 
       def init(monitor)
@@ -67,7 +67,7 @@ module Ragios
       end
 
       def take_screenshot
-        if not(@has_screenshot) 
+        if RAGIOS_HERCULES_ENABLE_SCREENSHOTS && not(@has_screenshot) 
           @screenshot_url = @browser.capture_screenshot 
           @has_screenshot = true
         end

--- a/lib/uptime_monitor/uptime_monitor.rb
+++ b/lib/uptime_monitor/uptime_monitor.rb
@@ -30,7 +30,7 @@ module Ragios
         browser_reader = Hercules::UptimeMonitor::BrowserReader.new(@monitor.browser)
         start_browser(@monitor.url, browser_reader.browser_name, browser_reader.headless)
         exists(@monitor.exists?)
-        @test_result = {results: @result_set }
+        @test_result = {results: @result_set}
         @test_result[:screenshot] = @screenshot_url if @has_screenshot
         close_browser
         @success
@@ -69,7 +69,7 @@ module Ragios
       end
 
       def take_screenshot
-        if RAGIOS_HERCULES_ENABLE_SCREENSHOTS && not(@has_screenshot) 
+        if RAGIOS_HERCULES_ENABLE_SCREENSHOTS && not(@monitor.disable_screenshots) && not(@has_screenshot) 
           @screenshot_url = @browser.capture_screenshot 
           @has_screenshot = true
         end

--- a/lib/uptime_monitor/uptime_monitor.rb
+++ b/lib/uptime_monitor/uptime_monitor.rb
@@ -24,6 +24,7 @@ module Ragios
       def test_command?
         @result_set = []
         @success = true
+        @has_screenshot = false
         browser_reader = Hercules::UptimeMonitor::BrowserReader.new(@monitor.browser)
         start_browser(@monitor.url, browser_reader.browser_name, browser_reader.headless)
         exists(@monitor.exists?)
@@ -49,7 +50,12 @@ module Ragios
 
       def exists(page_elements)
         page_elements.each do |page_element|
-          @browser.exists?(page_element) ? result!(page_element, true) : result!(page_element, false)
+          if @browser.exists?(page_element) 
+            result!(page_element, true) 
+          else 
+            take_screenshot
+            result!(page_element, false)
+          end
         end
       end
 
@@ -58,6 +64,13 @@ module Ragios
         result = state ? [page_element, "exists_as_expected"] : [page_element, "does_not_exist_as_expected"]
         @result_set << result
       end
+
+      def take_screenshot
+        if not(@has_screenshot) 
+          @browser.capture_screenshot 
+          @has_screenshot = true
+        end
+      end   
     end
   end
 end

--- a/lib/uptime_monitor/uptime_monitor.rb
+++ b/lib/uptime_monitor/uptime_monitor.rb
@@ -29,6 +29,7 @@ module Ragios
         start_browser(@monitor.url, browser_reader.browser_name, browser_reader.headless)
         exists(@monitor.exists?)
         @test_result = {results: @result_set }
+        @test_result[:screenshot] = @screenshot_url if @has_screenshot
         close_browser
         @success
       rescue Net::ReadTimeout => e
@@ -67,7 +68,7 @@ module Ragios
 
       def take_screenshot
         if not(@has_screenshot) 
-          @browser.capture_screenshot 
+          @screenshot_url = @browser.capture_screenshot 
           @has_screenshot = true
         end
       end   

--- a/spec/uptime_monitor_spec.rb
+++ b/spec/uptime_monitor_spec.rb
@@ -87,4 +87,19 @@ describe Ragios::Plugin::UptimeMonitor do
     @uptime_monitor.success.should == false     
     @uptime_monitor.close_browser
   end
+  it "can disable screenshot capture when a test fails for individual monitors" do 
+    page_element = [:title, [text: "dont_exist"]]
+    monitor = {
+      url: "http://obi-akubue.org",
+      browser: ["firefox", headless: true],
+      exists?: [page_element],
+      disable_screenshots: true
+    }
+    @uptime_monitor.init(monitor)
+    @uptime_monitor.test_command?.should == false
+    @uptime_monitor.has_screenshot.should == false
+    @uptime_monitor.screenshot_url.should == nil
+    @uptime_monitor.success.should == false 
+    @uptime_monitor.close_browser
+  end
 end

--- a/spec/uptime_monitor_spec.rb
+++ b/spec/uptime_monitor_spec.rb
@@ -40,6 +40,8 @@ describe Ragios::Plugin::UptimeMonitor do
     page_element = [:title]
     @uptime_monitor.exists([page_element])
     @uptime_monitor.test_result.should == {:results => [[page_element, "exists_as_expected"]]}
+    @uptime_monitor.has_screenshot.should == nil #since no test_command? was run
+    @uptime_monitor.screenshot_url.should == nil
     @uptime_monitor.success.should == nil #since no test_command? was run
     @uptime_monitor.close_browser
   end
@@ -50,6 +52,9 @@ describe Ragios::Plugin::UptimeMonitor do
     page_element = [:title, [text: "dont_exist"]]
     @uptime_monitor.exists([page_element])
     @uptime_monitor.test_result.should == {:results => [[page_element, "does_not_exist_as_expected"]]}
+    if @uptime_monitor.has_screenshot
+      !!(/^.*\.png$/.match(@uptime_monitor.screenshot_url)).should == true
+    end
     @uptime_monitor.success.should == false
     @uptime_monitor.close_browser
   end
@@ -62,6 +67,10 @@ describe Ragios::Plugin::UptimeMonitor do
     @uptime_monitor.init(monitor)
     @uptime_monitor.test_command?.should == true
     @uptime_monitor.test_result.should == {:results => [[page_element, "exists_as_expected"]]}
+    @uptime_monitor.has_screenshot.should == false
+    @uptime_monitor.screenshot_url.should == nil
+    @uptime_monitor.success.should == true 
+    @uptime_monitor.close_browser
   end
   it "runs a test that fails" do
     page_element = [:title, [text: "dont_exist"]]
@@ -72,5 +81,10 @@ describe Ragios::Plugin::UptimeMonitor do
     @uptime_monitor.init(monitor)
     @uptime_monitor.test_command?.should == false
     @uptime_monitor.test_result.should  include(:results => [[page_element, "does_not_exist_as_expected"]])
+    if @uptime_monitor.has_screenshot
+      !!(/^.*\.png$/.match(@uptime_monitor.screenshot_url)).should == true
+    end
+    @uptime_monitor.success.should == false     
+    @uptime_monitor.close_browser
   end
 end

--- a/spec/uptime_monitor_spec.rb
+++ b/spec/uptime_monitor_spec.rb
@@ -71,6 +71,6 @@ describe Ragios::Plugin::UptimeMonitor do
               }
     @uptime_monitor.init(monitor)
     @uptime_monitor.test_command?.should == false
-    @uptime_monitor.test_result.should == {:results => [[page_element, "does_not_exist_as_expected"]]}
+    @uptime_monitor.test_result.should  include(:results => [[page_element, "does_not_exist_as_expected"]])
   end
 end


### PR DESCRIPTION
This adds the option to include a screenshot of the current webpage when a transaction fails, so that a site admin can see when the site looks like when the transaction fails.

# Screenshots
The uptime_monitor can be configured to take a screenshot of the webpage when a test fails. This screenshot is uploaded to Amazon s3 and its url is included in the test_result. So the website admin can see what the site looks like when transaction failed.

This feature is disable by default, to enable it set following environment variable.
```
RAGIOS_HERCULES_ENABLE_SCREENSHOTS=true
```
Also set environment variables for the Amazon s3 account you want to use for storing the screenshots,
```
AWS_ACCESS_KEY_ID=xxxxxxx
AWS_SECRET_ACCESS_KEY=xxxxxx
RAGIOS_HERCULES_S3_DIR=xxxxxx
```
The above env vars are for the Amazon AWS access key, AWS secret key and s3 directory/bucket you want to use for storage. First create this s3 bucket manually.

With the screenshots feature enabled, the results of a failed test will include a screenshot of the webpage when the test failed.
See an example below:
```ruby
require 'uptime_monitor'

page_element = [:title, [text: "dont_exist"]]
monitor = {
  url: "http://obi-akubue.org",
  browser: ["firefox", headless: true],
  exists?: [page_element]
}

u = Ragios::Plugin::UptimeMonitor.new
u.init(monitor)
u.test_command?
#=>false
u.test_result
#=>  {
#      :results=>
#        [
#          [[:title, [{:text=>"dont_exist"}]], "does_not_exist_as_expected"]
#        ],
#      :screenshot=>
#        "http://screenshot-ragios.s3.amazonaws.com/uploads/screenshot1428783237.png"
#    }
```
Notice that test result includes a url to the screenshot of the webpage when the test failed. This test result is also included in the notifications sent to site admin by by Ragios when a test fails. So this way the admin can see exactly what webpage looked like when the transaction failed.

## Disable screenshots on individual monitors
To disable screenshots on a particular monitor add the key/value pair ```disable_screenshots: true```
example:
```ruby
page_element = [:title]
monitor = {
  url: "http://obi-akubue.org",
  browser: ["firefox", headless: true],
  exists?: [page_element],
  disable_screenshots: true
}

ragios.create(monitor)
```
This will diable screenshots only for this monitor, no screenshots will be taken when its test fails.
